### PR TITLE
Adding support for Python 3 & more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,10 @@ coverage.xml
 # Django stuff:
 *.log
 
+# editor
+*.ropeproject
+*.swp
+
 # Sphinx documentation
 docs/_build/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.2"
   - "3.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "3.2"
+  - "3.3"
+  - "3.4"
+  - "pypy3"
+
+# command to install dependencies
+install:
+  - pip install -r requirements.txt
+
+# command to run tests
+script: python test_chameleon.py

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Chameleon
+[![Build Status](https://travis-ci.org/agamdua/chameleon.svg?branch=master)](https://travis-ci.org/agamdua/chameleon)
+
+
 Chameleon is a test server which can be used with the Python test frameworks like Robot Framework.
 It mocks the behavior of third-party communications so that third party services do not need to be directly accessed during tests.  The goal is to remove outside dependencies from automated tests.
 

--- a/chameleon.py
+++ b/chameleon.py
@@ -92,17 +92,24 @@ def _get_cherrypy_page_handler(status_code, content_type, content):
         @cherrypy.expose
         @cherrypy.tools.json_out()
         def index(self, **kwargs):
+            """Determines response of each route specified in the server
+            settings of the `start()` method """
             cherrypy.response.status = status_code
             cherrypy.response.headers['Content-Type'] = content_type
+
+            # TODO: this is really ugly, need to look more into cherrypy
             return json.loads(content) if 'json' in content_type else content
     return Foo()
 
 
-def _validate_response_settings(response_settings):
-    """ Iterates through all the settings to check:
+def _validate_response_settings(response_settings, strict_mode=False):
+    """Iterates through all the settings to check:
         - if they exist
         - if they are of the correct data type
     """
+    if strict_mode:
+        raise NotImplementedError
+
     error_message = "Please include a '{}' key for all response settings"
     required = ("url", "status_code", "content_type", "content",)
 

--- a/chameleon.py
+++ b/chameleon.py
@@ -1,5 +1,14 @@
+from __future__ import print_function, unicode_literals
+
+import itertools
+
 import cherrypy
-from   types import StringType, IntType
+import six
+
+try:
+    import simplejson as json
+except ImportError:
+    import json  # noqa
 
 
 def start(response_settings, port=8080):
@@ -12,25 +21,31 @@ def start(response_settings, port=8080):
     automated testing.
 
     Args:
-        response_settings (dict): a JSON-style list of dicts which contains all of the 
-            request and response params for the simulating server to use
+        response_settings (dict): a JSON-style list of dicts which contains all
+            of the request and response params for the simulating server to use
             There should be one item in the list for each URL the service should
             listen to requests on.
             Each dictionary should contain a:
                 * url: something like "/path1"
                 * status_code: The HTTP status code to return.  E.g. 200
-                * content_type: The mime-type of the response.  
-                                E.g. "text/xml" or "application/json" 
+                * content_type: The mime-type of the response.
+                                E.g. "text/xml" or "application/json"
                                      or "text/html"
                 * content:  some JSON, XML, HTTP, or other string to return
                             as the response content.
 
-            Example: 
-                [{"url": "/path1", "status_code": 200, "content_type": "application/json", 
+            Example:
+                [{"url": "/path1",
+                  "status_code": 200,
+                  "content_type": "application/json",
                   "content": "{'foo': 'bar'}"},
-                 {"url": "/path2", "status_code": 404, "content_type": "text/html", 
-                  "content": "<html><body><p>Page not found!</p></body></html>"},
-                 {"url": "/path3", "status_code": 200, "content_type": "text/xml", 
+                 {"url": "/path2",
+                  "status_code": 404,
+                  "content_type": "text/html",
+                  "content": "<html><body><p>Page not found</p></body></html>"},
+                 {"url": "/path3",
+                  "status_code": 200,
+                  "content_type": "text/xml",
                   "content": "<foo>bar</foo>"},]
 
         port (int): the port number this server should run on.  Default is 8080.
@@ -43,18 +58,25 @@ def start(response_settings, port=8080):
             url = setting['url']
             if not url.startswith('/'):
                 url = '/' + url
+
             content = setting['content']
             content_type = setting['content_type']
             status_code = setting['status_code']
 
-            config_instance = _get_cherrypy_page_handler(status_code, content_type, content)
+            config_instance = _get_cherrypy_page_handler(
+                status_code, content_type, content
+            )
             cherrypy.tree.mount(config_instance, url)
 
-        cherrypy.config.update({'server.socket_port': port})
+        cherrypy.config.update({'server.socket_port': port, })
+
         cherrypy.engine.start()
-    except Exception, e:
-        print "Exception '%s' occurred.  Killing the mock server." % str(e)
-        stop_mock_service()
+
+    except Exception as e:
+        # TODO: Investigate; I think cherrypy kills the process before the
+        # execution even reaches this point
+        print("Exception '%s' occurred.  Killing the mock server." % str(e))
+        stop()
         raise
 
 
@@ -68,20 +90,28 @@ def stop():
 def _get_cherrypy_page_handler(status_code, content_type, content):
     class Foo(object):
         @cherrypy.expose
+        @cherrypy.tools.json_out()
         def index(self, **kwargs):
             cherrypy.response.status = status_code
-            cherrypy.response.headers['Content-Type']= content_type
-            return content
+            cherrypy.response.headers['Content-Type'] = content_type
+            return json.loads(content) if 'json' in content_type else content
     return Foo()
 
 
 def _validate_response_settings(response_settings):
-    for setting in response_settings:
-        assert "url" in setting, "Please include a 'url' key for all response settings"
-        assert "status_code" in setting, "Please include a 'status_code' key for all response settings"
-        assert "content_type" in setting, "Please include a 'content_type' key for all response settings"
-        assert "content" in setting, "Please include a 'content' key for all response settings"
-        assert type(setting['url']) is StringType
-        assert type(setting['status_code']) is IntType
-        assert type(setting['content_type']) is StringType
-        assert type(setting['content']) is StringType
+    """ Iterates through all the settings to check:
+        - if they exist
+        - if they are of the correct data type
+    """
+    error_message = "Please include a '{}' key for all response settings"
+    required = ("url", "status_code", "content_type", "content",)
+
+    # Not sure if this "type checking" will be scalable with multiple responses,
+    # might be best to make it a configurable option and left to the user's
+    # discretion. A 'strict' mode, if you please.
+    for field, setting in itertools.product(required, response_settings):
+        assert field in setting, error_message.format(field)
+        assert isinstance(setting['url'], six.string_types)
+        assert isinstance(setting['status_code'], six.integer_types)
+        assert isinstance(setting['content_type'], six.string_types)
+        assert isinstance(setting['content'], six.string_types)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 CherryPy==3.7.0
 six==1.9.0
 
-# this should be moved to a requirements/test.txt
+# TODO: this should be moved to a requirements/test.txt
 requests==2.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+CherryPy==3.7.0
+six==1.9.0
+
+# this should be moved to a requirements/test.txt
+requests==2.7.0

--- a/test_chameleon.py
+++ b/test_chameleon.py
@@ -4,6 +4,9 @@ import requests
 
 
 class ChameleonTests(unittest.TestCase):
+    def setUp(self):
+        self.port = 7001  # uncommon port
+
     def tearDown(self):
         chameleon.stop()
 
@@ -11,48 +14,74 @@ class ChameleonTests(unittest.TestCase):
         """
         Mock server with a single URL returning a successful JSON response
         responds to queries as expected.
-        Port defaults to 8080.
         """
-        settings_list = [{"url": "/path1",
-                          "status_code": 200,
-                          "content_type": "application/json",
-                          "content": '{"foo": "bar"}'}]
-        chameleon.start(settings_list)
-        response = requests.get('http://localhost:8080/path1')
+        settings_list = [{
+            "url": "/path1",
+            "status_code": 200,
+            "content_type": "application/json",
+            "content": '{"foo": "bar"}'
+        }]
+
+        chameleon.start(settings_list, port=self.port)
+        response = requests.get('http://localhost:{}/path1'.format(self.port))
+
+        # basic content stuff
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content, b'{"foo": "bar"}')
-        self.assertEqual(response.json()['foo'], 'bar')  # ensure response decoded as JSON.
+
+        # ensure response decoded as JSON.
+        self.assertEqual(response.json()['foo'], 'bar')
         self.assertEqual(response.headers['content-type'], 'application/json')
+
+    def test_content_type_xml(self):
+        settings_list = [{
+            "url": "/path1",
+            "status_code": 200,
+            "content_type": "application/xml",
+            "content": '<foo>bar</foo>'
+        }]
+        chameleon.start(settings_list, port=self.port)
+        response = requests.get('http://localhost:{}/path1'.format(self.port))
+        self.assertEqual(response.content, b'"<foo>bar</foo>"')
+        self.assertEqual(response.headers['content-type'], 'application/xml')
 
     def test_multiple_services(self):
         """
         Multiple URLs can be served by the mock server at once.
         Custom ports other than 8080 also work.
         """
-        settings_list = [{"url": "/path1",
-                          "status_code": 200,
-                          "content_type": "application/json",
-                          "content": '{"foo": "bar"}'},
-                         {"url": "path2",
-                          "status_code": 404,
-                          "content_type": "text/html",
-                          "content": 'Page not found'}]
-        chameleon.start(settings_list, port=8000)
+        settings_list = [
+            {"url": "/path1",
+             "status_code": 200,
+             "content_type": "application/json",
+             "content": '{"foo": "bar"}'},
+            {"url": "path2",
+             "status_code": 404,
+             "content_type": "text/html",
+             "content": 'Page not found'}
+        ]
+        chameleon.start(settings_list, port=self.port)
 
         # test path1 - the successful response
-        response = requests.get('http://localhost:8000/path1')
+        response = requests.get('http://localhost:{}/path1'.format(self.port))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content, b'{"foo": "bar"}')
         self.assertEqual(response.json()['foo'], 'bar')  # ensure response decoded as JSON.
         self.assertEqual(response.headers['content-type'], 'application/json')
 
         # test path2 - the page-not-found path
-        response = requests.get('http://localhost:8000/path2')
+        response = requests.get('http://localhost:{}/path2'.format(self.port))
         self.assertEqual(response.status_code, 404)
         self.assertEqual(response.content, b'"Page not found"')
         self.assertTrue(
             response.headers['content-type'].startswith('text/html')
         )
+
+    @unittest.expectedFailure
+    def test_strict_mode(self):
+        """Placeholder: Not implemented yet """
+        self.assertFalse(True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test_chameleon.py
+++ b/test_chameleon.py
@@ -1,7 +1,7 @@
 import unittest
 import chameleon
 import requests
-import simplejson as json
+
 
 class ChameleonTests(unittest.TestCase):
     def tearDown(self):
@@ -13,14 +13,14 @@ class ChameleonTests(unittest.TestCase):
         responds to queries as expected.
         Port defaults to 8080.
         """
-        settings_list = [{"url": "/path1", 
-                          "status_code": 200, 
-                          "content_type": "application/json", 
+        settings_list = [{"url": "/path1",
+                          "status_code": 200,
+                          "content_type": "application/json",
                           "content": '{"foo": "bar"}'}]
         chameleon.start(settings_list)
         response = requests.get('http://localhost:8080/path1')
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, '{"foo": "bar"}')
+        self.assertEqual(response.content, b'{"foo": "bar"}')
         self.assertEqual(response.json()['foo'], 'bar')  # ensure response decoded as JSON.
         self.assertEqual(response.headers['content-type'], 'application/json')
 
@@ -29,25 +29,30 @@ class ChameleonTests(unittest.TestCase):
         Multiple URLs can be served by the mock server at once.
         Custom ports other than 8080 also work.
         """
-        settings_list = [{"url": "/path1", 
-                          "status_code": 200, 
-                          "content_type": "application/json", 
+        settings_list = [{"url": "/path1",
+                          "status_code": 200,
+                          "content_type": "application/json",
                           "content": '{"foo": "bar"}'},
-                         {"url": "path2", 
-                          "status_code": 404, 
-                          "content_type": "text/html", 
+                         {"url": "path2",
+                          "status_code": 404,
+                          "content_type": "text/html",
                           "content": 'Page not found'}]
         chameleon.start(settings_list, port=8000)
 
         # test path1 - the successful response
         response = requests.get('http://localhost:8000/path1')
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, '{"foo": "bar"}')
+        self.assertEqual(response.content, b'{"foo": "bar"}')
         self.assertEqual(response.json()['foo'], 'bar')  # ensure response decoded as JSON.
         self.assertEqual(response.headers['content-type'], 'application/json')
 
         # test path2 - the page-not-found path
         response = requests.get('http://localhost:8000/path2')
         self.assertEqual(response.status_code, 404)
-        self.assertEqual(response.content, 'Page not found')
-        self.assertTrue(response.headers['content-type'].startswith('text/html'))
+        self.assertEqual(response.content, b'"Page not found"')
+        self.assertTrue(
+            response.headers['content-type'].startswith('text/html')
+        )
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Just pasting the [main commit](https://github.com/macie-korte/chameleon/commit/ce36334d959eed7e38840f6dcc0f9bd9367b51ba) message

> # Python 3
> 
> Python 3 support mainly required a change in how the data was passed
> around - cherrypy is smart enough to distinguish between bytes and
> chars (which is expected if it is providing Py3 support)
> 
> This also updated the page handler to conditionally return JSON back
> dependent on content type. This logic _may_ look brittle but it should
> work just fine.
> # Other Stuff
> - runnable unittest files
> - requirements.txt!
> - bug where function name was incorrect (stop_mock_service -> stop)
> - PEP8 (especially 80char lines)
> - Some refactoring where DRY-ness could be added
> - simplejson was added, but not as a hard dependency

Also added travis for builds
